### PR TITLE
adding a separate PIN show field, with a reset switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bond-sdk-cards",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Bond Card Management SDK",
   "main": "./dist/bond-sdk-cards.js",
   "scripts": {

--- a/src/bond-sdk-cards.js
+++ b/src/bond-sdk-cards.js
@@ -248,6 +248,8 @@ class BondCards {
     if( currentPin && currentPin.length > 0 ) {
       console.log( `adding current pin: ${currentPin}` );
       options.data.current_pin = currentPin;
+    } else {
+      console.log( `NOT adding current pin: ${currentPin}` );
     }
 
     return new Promise((resolve, reject) => {

--- a/src/bond-sdk-cards.js
+++ b/src/bond-sdk-cards.js
@@ -246,6 +246,7 @@ class BondCards {
 
     // add currentPin only if provided and not trivial
     if( currentPin && currentPin.length > 0 ) {
+      console.log( `adding current pin: ${currentPin}` );
       options.data.current_pin = currentPin;
     }
 

--- a/src/bond-sdk-cards.js
+++ b/src/bond-sdk-cards.js
@@ -31,7 +31,7 @@ class BondCards {
   }
 
   /**
-   * @description Show appropriate card data
+   * @description Show card data including number, expiry, cvv
    * @param {String} cardId The unique ID used to identify a specific card.
    * @param {String} identity The temporary identity token allowing this call.
    * @param {String} authorization The temporary authorization token.
@@ -83,6 +83,56 @@ class BondCards {
       }
     });
   }
+
+  /**
+   * @description Show card PIN data
+   * @param {String} cardId The unique ID used to identify a specific card.
+   * @param {String} identity The temporary identity token allowing this call.
+   * @param {String} authorization The temporary authorization token.
+   * @param {Boolean} [reset=false] Reset the PIN and view
+   * @param {String} [htmlWrapper="text"] The expected type of response data.
+   * 'image' is wrapped in an <img src='<revealed_data>'/> HTML tag. 'text'
+   * would be inserted into a <span> element inside the iframe.
+   * @param {String} htmlSelector A selector for the field/element where the
+   * iFrame will be placed.
+   * @param {Object} [css={}] An object of CSS rules to apply to the response.
+   * @return {Promise} Returns a Promise that, when fulfilled,
+   * will either return an iFrame with the appropriate data or an error.
+   */
+  showPIN({
+    cardId,
+    identity,
+    authorization,
+    reset = false,
+    htmlWrapper = "text",
+    htmlSelector,
+    css = {},
+  }) {
+
+    const requestParams = {
+      method: reset ? "PATCH" : "GET",
+      headers: {
+        "Content-type": "application/json",
+        Identity: identity,
+        Authorization: authorization,
+      },
+      path: `${this.BONDSTUDIO}/${cardId}/pin`,
+      name: "pin",
+      // The JSONPath that the request will show the value for
+      jsonPathSelector: "pin",
+      htmlWrapper,
+    };
+
+    return new Promise((resolve, reject) => {
+      const newIframe = this.internalShow.request(requestParams);
+      if (newIframe) {
+        resolve(newIframe.render(htmlSelector, css));
+      } else {
+        reject();
+      }
+    });
+  }
+
 
   /**
    * @description Initilize a Field in a Form to submit for card manipulation

--- a/src/bond-sdk-cards.js
+++ b/src/bond-sdk-cards.js
@@ -252,6 +252,8 @@ class BondCards {
       console.log( `NOT adding current pin: ${currentPin}` );
     }
 
+    console.log(options);
+
     return new Promise((resolve, reject) => {
       const submitResult = this.internalForm.submit(
         `${this.BONDSTUDIO}/set_pin`,

--- a/src/bond-sdk-cards.js
+++ b/src/bond-sdk-cards.js
@@ -244,16 +244,6 @@ class BondCards {
       },
     };
 
-    // add currentPin only if provided and not trivial
-    if( currentPin && currentPin.length > 0 ) {
-      console.log( `adding current pin: ${currentPin}` );
-      options.data.current_pin = currentPin;
-    } else {
-      console.log( `NOT adding current pin: ${currentPin}` );
-    }
-
-    console.log(options);
-
     return new Promise((resolve, reject) => {
       const submitResult = this.internalForm.submit(
         `${this.BONDSTUDIO}/set_pin`,

--- a/src/bond-sdk-cards.js
+++ b/src/bond-sdk-cards.js
@@ -226,7 +226,7 @@ class BondCards {
     cardId,
     identity,
     authorization,
-    currentPin,
+    currentPin = undefined,
     newPin,
     successCallback,
     errorCallback,
@@ -240,10 +240,14 @@ class BondCards {
       },
       data: {
         card_id: cardId,
-        current_pin: currentPin,
         new_pin: newPin,
       },
     };
+
+    // add currentPin only if provided
+    if( currentPin ) {
+      options.data.current_pin = currentPin;
+    }
 
     return new Promise((resolve, reject) => {
       const submitResult = this.internalForm.submit(

--- a/src/bond-sdk-cards.js
+++ b/src/bond-sdk-cards.js
@@ -244,8 +244,8 @@ class BondCards {
       },
     };
 
-    // add currentPin only if provided
-    if( currentPin ) {
+    // add currentPin only if provided and not trivial
+    if( currentPin && currentPin.length > 0 ) {
       options.data.current_pin = currentPin;
     }
 


### PR DESCRIPTION
This PR adds a "show" like field in the BondCards object that can revel PINs if we know the route/method to call at our backend. 